### PR TITLE
Added siren park kill feature (client and server)

### DIFF
--- a/ELS-FiveM/client/playervehicle.lua
+++ b/ELS-FiveM/client/playervehicle.lua
@@ -1,0 +1,48 @@
+local isInVehicle = false
+local isEnteringVehicle = false
+local currentVehicle = 0
+
+RegisterNetEvent("els:setSirenParkKill_s")
+
+Citizen.CreateThread(function()
+	while true do
+		Citizen.Wait(0)
+
+		local ped = PlayerPedId()
+
+		if not isInVehicle and not IsPlayerDead(PlayerId()) then
+			if DoesEntityExist(GetVehiclePedIsTryingToEnter(ped)) and not isEnteringVehicle then
+				-- Entering vehicle
+				local vehicle = GetVehiclePedIsTryingToEnter(ped)
+				local seat = GetSeatPedIsTryingToEnter(ped)
+				local netId = VehToNet(vehicle)
+				isEnteringVehicle = true
+			elseif not DoesEntityExist(GetVehiclePedIsTryingToEnter(ped)) and not IsPedInAnyVehicle(ped, true) and isEnteringVehicle then
+				-- Vehicle entering aborted
+				isEnteringVehicle = false
+			elseif IsPedInAnyVehicle(ped, false) then
+				-- Suddenly appeared in a vehicle (possible teleport)
+				isEnteringVehicle = false
+				isInVehicle = true
+				currentVehicle = GetVehiclePedIsUsing(ped)
+				local model = GetEntityModel(currentVehicle)
+				local name = GetDisplayNameFromVehicleModel()
+				local netId = VehToNet(currentVehicle)
+			end
+		elseif isInVehicle then
+			if not IsPedInAnyVehicle(ped, false) or IsPlayerDead(PlayerId()) then
+				-- bye, vehicle
+				local model = GetEntityModel(currentVehicle)
+				local name = GetDisplayNameFromVehicleModel()
+				local netId = VehToNet(currentVehicle)
+                local vehicle = NetworkGetEntityFromNetworkId(netId)
+                if GetVehicleClass(vehicle) == 18 then
+                    TriggerServerEvent("els:setSirenParkKill_s", 0, vehicle)
+                end
+				isInVehicle = false
+				currentVehicle = 0
+			end
+		end
+		Citizen.Wait(50)
+	end
+end)

--- a/ELS-FiveM/client/util.lua
+++ b/ELS-FiveM/client/util.lua
@@ -197,6 +197,19 @@ AddEventHandler("els:setSirenState_c", function(sender, newstate)
     end 
 end)
 
+RegisterNetEvent("els:setSirenParkKill_c")
+AddEventHandler("els:setSirenParkKill_c", function(sender, newstate, veh)
+	if sirenParkKillEnabled then
+		local player_s = GetPlayerFromServerId(sender)
+		if player_s ~= -1 then 
+			local ped_s = GetPlayerPed(player_s)
+			if DoesEntityExist(ped_s) and not IsEntityDead(ped_s) then
+				setSirenState(veh, newstate)
+			end
+		end 
+	end
+end)
+
 RegisterNetEvent("els:setHornState_c")
 AddEventHandler("els:setHornState_c", function(sender, newstate)
     local player_s = GetPlayerFromServerId(sender)
@@ -305,34 +318,35 @@ end
 function setSirenState(veh, newstate)
     if DoesEntityExist(veh) and not IsEntityDead(veh) then
         if newstate ~= m_siren_state[veh] then
-                
-            if m_soundID_veh[veh] ~= nil then
-                StopSound(m_soundID_veh[veh])
-                ReleaseSoundId(m_soundID_veh[veh])
-                m_soundID_veh[veh] = nil
-            end
-                        
-            if newstate == 1 then
-
-                m_soundID_veh[veh] = GetSoundId()
-                PlaySoundFromEntity(m_soundID_veh[veh], getVehicleVCFInfo(veh).sounds.srnTone1.audioString, veh, 0, 0, 0)
-                toggleSirenMute(veh, true)
-                
-            elseif newstate == 2 then
-
-                m_soundID_veh[veh] = GetSoundId() 
-                PlaySoundFromEntity(m_soundID_veh[veh], getVehicleVCFInfo(veh).sounds.srnTone2.audioString, veh, 0, 0, 0)
-                toggleSirenMute(veh, true)
-                
-            elseif newstate == 3 then
-
-                m_soundID_veh[veh] = GetSoundId()
-                PlaySoundFromEntity(m_soundID_veh[veh], getVehicleVCFInfo(veh).sounds.srnTone3.audioString, veh, 0, 0, 0)
-                toggleSirenMute(veh, true)
-                
-            else
-                toggleSirenMute(veh, true)
-            end             
+			
+				if m_soundID_veh[veh] ~= nil then
+					StopSound(m_soundID_veh[veh])
+					ReleaseSoundId(m_soundID_veh[veh])
+					m_soundID_veh[veh] = nil
+				end
+							
+				if newstate == 1 then
+					
+					m_soundID_veh[veh] = GetSoundId()
+					PlaySoundFromEntity(m_soundID_veh[veh], getVehicleVCFInfo(veh).sounds.srnTone1.audioString, veh, 0, 0, 0)
+					toggleSirenMute(veh, true)
+					
+				elseif newstate == 2 then
+					
+					m_soundID_veh[veh] = GetSoundId() 
+					PlaySoundFromEntity(m_soundID_veh[veh], getVehicleVCFInfo(veh).sounds.srnTone2.audioString, veh, 0, 0, 0)
+					toggleSirenMute(veh, true)
+					
+				elseif newstate == 3 then
+					
+					m_soundID_veh[veh] = GetSoundId()
+					PlaySoundFromEntity(m_soundID_veh[veh], getVehicleVCFInfo(veh).sounds.srnTone3.audioString, veh, 0, 0, 0)
+					toggleSirenMute(veh, true)
+					
+				else
+					
+					toggleSirenMute(veh, true)
+				end             
                 
             m_siren_state[veh] = newstate
         end

--- a/ELS-FiveM/config.lua
+++ b/ELS-FiveM/config.lua
@@ -6,6 +6,7 @@ vehicleSyncDistance = 150
 environmentLightBrightness = 0.006
 lightDelay = 10 -- Time in MS
 flashDelay = 15
+sirenParkKillEnabled = true
 
 panelEnabled = true
 panelType = "original"
@@ -20,27 +21,27 @@ allowedPanelTypes = {
 -- https://docs.fivem.net/game-references/controls
 
 shared = {
-    horn = 86,
+    horn = 86,			-- E
 }
 
 keyboard = {
-    modifyKey = 132,
-    stageChange = 85, -- Q
-    guiKey = 199, -- P
-    takedown = 83, -- =
+    modifyKey = 131,	-- LEFT SHIFT
+    stageChange = 85,	-- Q
+    guiKey = 199,		-- P
+    takedown = 83,		-- =
     siren = {
-        tone_one = 157, -- 1
-        tone_two = 158, -- 2
+        tone_one = 157,	-- 1
+        tone_two = 158,	-- 2
         tone_three = 160, -- 3
     },
     pattern = {
-        primary = 163, -- 9
+        primary = 161,	-- 7
         secondary = 162, -- 8
-        advisor = 161, -- 7
+        advisor = 163,	-- 9
     },
-    warning = 246, -- Y
-    secondary = 303, -- U
-    primary = 7, -- ?? 
+	warning = 108,		-- NUMPAD 4
+	secondary = 110,	-- NUMPAD 5
+	primary = 109,		-- NUMPAD 6
 }
 
 controller = {

--- a/ELS-FiveM/server/server.lua
+++ b/ELS-FiveM/server/server.lua
@@ -848,6 +848,11 @@ AddEventHandler("els:setSirenState_s", function(newstate)
     TriggerClientEvent("els:setSirenState_c", -1, source, newstate)
 end)
 
+RegisterNetEvent("els:setSirenParkKill_s")
+AddEventHandler("els:setSirenParkKill_s", function(newstate, vehicle)
+    TriggerClientEvent("els:setSirenParkKill_c", -1, source, newstate, vehicle)
+end)
+
 RegisterNetEvent("els:setDualSirenState_s")
 AddEventHandler("els:setDualSirenState_s", function(newstate)
     TriggerClientEvent("els:setDualSirenState_c", -1, source, newstate)


### PR DESCRIPTION
Added siren park kill feature - active siren is muted upon exiting an ELS vehicle.
Useful when attending scene without continued siren use/faffing around turning the siren off prior to exit.